### PR TITLE
Fix undefined variable in ProductController vendor lookup

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -34,7 +34,7 @@ class ProductController extends Controller
 	    $searchterm = $request->input('VendorName');
     	$vendors = \DB::table('vendors')->where('VendorName', 'like', '%'.$searchterm.'%')->get();
 
-        return view('product.vendorlist',compact('vendors','active'));
+        return view('product.vendorlist', compact('vendors'));
     }
     
     public function vendor($vendor)


### PR DESCRIPTION
## Summary
- remove nonexistent `active` variable from `ProductController::returnvendor`

## Testing
- `vendor/bin/phpunit` *(fails: Fatal error: Cannot acquire reference to $GLOBALS in vendor/phpunit/phpunit/src/Util/Configuration.php on line 504)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d9573c74833084f693017921d08c