### PR TITLE
Enable column sorting on vendor pricing page

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -40,17 +40,34 @@ class ProductController extends Controller
         return view('product.vendorlist', compact('vendors'));
     }
     
-    public function vendor($vendor)
+    public function vendor(Request $request, $vendor)
     {
+        $allowedSorts = ['ProductCode', 'VendorProductCode', 'ProductName', 'Cost', 'ProductPrice', 'msrp', 'lastupdate'];
+        $sort = $request->input('sort', 'ProductName');
+        if (!in_array($sort, $allowedSorts)) {
+            $sort = 'ProductName';
+        }
+        $direction = $request->input('direction', 'asc');
+        $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
+
         $products = \DB::table('vendorrules')
             ->where('VendorName', $vendor)
-            ->orderBy('ProductName', 'asc')
+            ->orderBy($sort, $direction)
             ->get();
-        return view('product.vendorproductlist',compact('products','vendor'));
+
+        return view('product.vendorproductlist', compact('products', 'vendor', 'sort', 'direction'));
     }
 
     public function updatevendor(Request $request, $vendor)
     {
+
+        $allowedSorts = ['ProductCode', 'VendorProductCode', 'ProductName', 'Cost', 'ProductPrice', 'msrp', 'lastupdate'];
+        $sort = $request->input('sort', 'ProductName');
+        if (!in_array($sort, $allowedSorts)) {
+            $sort = 'ProductName';
+        }
+        $direction = $request->input('direction', 'asc');
+        $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
 
         $active=$request->input('button');
 
@@ -58,10 +75,10 @@ class ProductController extends Controller
                 $products = \DB::table('vendorrules')
                     ->where('VendorName', $vendor)
                     ->where('active','1')
-                    ->orderBy('ProductName', 'asc')
+                    ->orderBy($sort, $direction)
                     ->get();
 
-            return view('product.vendorproductlist',compact('products','vendor'));
+            return view('product.vendorproductlist',compact('products','vendor','sort','direction'));
         }
         for ($i = 0; $i < sizeof($request->input('productcode')); $i++) {
 
@@ -88,9 +105,9 @@ class ProductController extends Controller
 
         $products = \DB::table('vendorrules')
             ->where('VendorName', $vendor)
-            ->orderBy('ProductName', 'asc')
+            ->orderBy($sort, $direction)
             ->get();
-        return view('product.vendorproductlist',compact('products','vendor'));
+        return view('product.vendorproductlist',compact('products','vendor','sort','direction'));
     }
     
     public function bulkdiscontinue()

--- a/resources/views/product/vendorproductlist.blade.php
+++ b/resources/views/product/vendorproductlist.blade.php
@@ -10,10 +10,20 @@
                     <button type="submit" class="btn btn-primary btn-xs" name="button" style="float: right;" value="update">Save</button>
                     <button type="submit" class="btn btn-primary btn-xs" name="button" style="float: right;" value="active">Active</button>
                 </div>
-		<div class="panel-body">
+                <div class="panel-body">
                         <table class="table">
-                        <tr><th>Product Code</th><th>Vendor Product Code</th><th>Product Name</th><th>Cost</th><th>Price</th><th>MSRP</th><th>Last Updated</th></tr>
+                        <tr>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=ProductCode&direction={{ ($sort == 'ProductCode' && $direction == 'asc') ? 'desc' : 'asc' }}">Product Code</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=VendorProductCode&direction={{ ($sort == 'VendorProductCode' && $direction == 'asc') ? 'desc' : 'asc' }}">Vendor Product Code</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=ProductName&direction={{ ($sort == 'ProductName' && $direction == 'asc') ? 'desc' : 'asc' }}">Product Name</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=Cost&direction={{ ($sort == 'Cost' && $direction == 'asc') ? 'desc' : 'asc' }}">Cost</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=ProductPrice&direction={{ ($sort == 'ProductPrice' && $direction == 'asc') ? 'desc' : 'asc' }}">Price</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=msrp&direction={{ ($sort == 'msrp' && $direction == 'asc') ? 'desc' : 'asc' }}">MSRP</a></th>
+                            <th><a href="{{ url('/') }}/product/vendor/{{$vendor}}?sort=lastupdate&direction={{ ($sort == 'lastupdate' && $direction == 'asc') ? 'desc' : 'asc' }}">Last Updated</a></th>
+                        </tr>
                         <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="sort" value="{{ $sort }}">
+                        <input type="hidden" name="direction" value="{{ $direction }}">
                         
                         @foreach ( $products as $product)
                             <input type="hidden" name="productcode[]" value="{{$product->ProductCode}}">


### PR DESCRIPTION
## Summary
- Allow sorting vendor products by any column with query params
- Add clickable table headers to toggle ascending/descending order

## Testing
- `./vendor/bin/phpunit` *(fails: Cannot acquire reference to $GLOBALS)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df3cf9b883308e6a979414e76737